### PR TITLE
Set inner box background to transparent

### DIFF
--- a/src/components/Main.astro
+++ b/src/components/Main.astro
@@ -256,14 +256,9 @@
   }
 
   .outer-box {
-    background: linear-gradient(
-      to right,
-      rgba(248, 245, 253, 0.5),
-      rgba(223, 214, 240, 0.5)
-    );
     width: 250px;
     height: 250px;
-    padding: var(--padding);
+    border: var(--padding) solid rgba(248, 245, 253, 0.5);
     border-radius: var(--outerBorder);
     transform: scale(var(--zoom));
     transform-origin: top left;
@@ -273,10 +268,10 @@
   .outer-box::before {
     content: "";
     position: absolute;
-    top: 0;
-    left: 0;
-    width: calc(100% - 6px);
-    height: calc(100% - 6px);
+    top: calc(var(--padding) * -1);
+    left: calc(var(--padding) * -1);
+    width: calc(100% - 6px + var(--padding) * 2);
+    height: calc(100% - 6px + var(--padding) * 2);
     border-radius: var(--outerBorder);
     border: 6px solid #dfd6f0;
 
@@ -287,7 +282,7 @@
   .inner-box {
     width: 100%;
     height: 100%;
-    background: #12022a;
+    background: transparent;
     border-radius: var(--innerBorder);
     position: relative;
   }


### PR DESCRIPTION
Allow a transparent background by using the outer box border instead of background.
This will replace the current gradient background with a single color border. 

Before:
![image](https://github.com/user-attachments/assets/0e5b824e-e9df-4f12-8b96-f8d86f44a0eb)
![image](https://github.com/user-attachments/assets/7641c9d6-ebc4-49e7-a332-69a05af4e2fd)

After:
![image](https://github.com/user-attachments/assets/d6917df2-1005-40b7-8dc6-f0655799ebbb)
![image](https://github.com/user-attachments/assets/9e5c53ae-861d-48e7-b282-1f63866e6ed4)
